### PR TITLE
Fix bug lookup user when creating merge request and add option for title

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ if your remote repository is not origin
 
 ### Create Merge Request
 
-	git gitlab merge SOURCE_BRANCH TARGET_BRANCH --assign USER_NAME
+	git gitlab merge SOURCE_BRANCH TARGET_BRANCH --assign USER_NAME --title MERGE_REQUEST_TITLE
 
 ### Get Mergerequest list
 
@@ -49,7 +49,7 @@ if your remote repository is not origin
 	git gitlab issue ISSUE_ID
 
 ### Code Review
-	
+
 	git gitlab review MERGEREQUEST_ID
 
 ## Contributing

--- a/bin/git-gitlab
+++ b/bin/git-gitlab
@@ -36,7 +36,7 @@ class GitGitlabCLI < Thor
       exit 0
     end
 
-    title = source
+    title = options[:title] || source
     assign = options[:assign]
     begin
       url = if target == nil
@@ -89,11 +89,11 @@ class GitGitlabCLI < Thor
 
   desc "review ID", "checkout mergerequest merged commit"
   def review(id)
-    
+
     begin
       remote = @gitlab.remote
       mergerequest = @gitlab.mergerequest(id)
-      
+
       repository = GitlabLocalRepository.new()
       repository.review("mergerequest/\##{id}" , mergerequest.source_branch, mergerequest.target_branch, remote)
       puts("When you finish code review,then")
@@ -114,7 +114,7 @@ class GitGitlabCLI < Thor
 
   def help
     user = @gitlab.authorize
-    puts("You are #{user.username}")    
+    puts("You are #{user.username}")
     puts("Gitlab is #{Gitlab.endpoint}")
     super
   end

--- a/lib/git/gitlab/api/mergerequest.rb
+++ b/lib/git/gitlab/api/mergerequest.rb
@@ -23,12 +23,10 @@ class GitlabApi::ApiClient
         source
       end
 
-      assignee_id = if assign == nil
-        0
-      else
-        @client.users.select { |user|
-          user.username == assign
-        }[0].id
+      assignee_id = 0
+      if assign
+        user = @client.users(per_page: 9_999).find { |u| u.username == assign }
+        assignee_id = user.id if user
       end
 
       begin


### PR DESCRIPTION
As `Gitlab.client.users` only returns the first 20 users by default, I faced runtime error when the assigned user not in this batch.
Those commits address this issue by adding per_page: 9999 option when query users.
Also, I add title option to support setting title for the merge request rather than use the source branch name.
