### PR TITLE
add missing dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ With go-lang already installed:
 $ brew install libgit2
 $ go get gopkg.in/libgit2/git2go.v22
 $ go get github.com/plouc/go-gitlab-client
+$ go get github.com/codegangsta/cli
 $ make build
 ~~~
 


### PR DESCRIPTION
It appears this dependency is commonly satisfied when people often use go, but as a first-time user, I did not have it yet.
