### PR TITLE
Bump git2go dependency to v23

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ go:
 install:
     - go get github.com/codegangsta/cli
     - cd "${HOME}"
-    - wget -O libgit2-0.22.1.tar.gz https://github.com/libgit2/libgit2/archive/v0.22.1.tar.gz
-    - tar -xzvf libgit2-0.22.1.tar.gz
-    - cd libgit2-0.22.1 && mkdir build && cd build
+    - wget -O libgit2-0.23.4.tar.gz https://github.com/libgit2/libgit2/archive/v0.23.4.tar.gz
+    - tar -xzvf libgit2-0.23.4.tar.gz
+    - cd libgit2-0.23.4 && mkdir build && cd build
     - cmake -DTHREADSAFE=ON -DBUILD_CLAR=OFF -DCMAKE_C_FLAGS=-fPIC -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DCMAKE_INSTALL_PREFIX=/usr/local .. && make && sudo make install
     - sudo ldconfig
     - cd "${TRAVIS_BUILD_DIR}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ install:
     - cmake -DTHREADSAFE=ON -DBUILD_CLAR=OFF -DCMAKE_C_FLAGS=-fPIC -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DCMAKE_INSTALL_PREFIX=/usr/local .. && make && sudo make install
     - sudo ldconfig
     - cd "${TRAVIS_BUILD_DIR}"
-    - go get gopkg.in/libgit2/git2go.v22
+    - go get gopkg.in/libgit2/git2go.v23
     - go get github.com/plouc/go-gitlab-client

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ With go-lang already installed:
 
 ~~~sh
 $ brew install libgit2
-$ go get gopkg.in/libgit2/git2go.v22
+$ go get gopkg.in/libgit2/git2go.v23
 $ go get github.com/plouc/go-gitlab-client
 $ go get github.com/codegangsta/cli
 $ make build

--- a/global-gitconfig.go
+++ b/global-gitconfig.go
@@ -1,6 +1,6 @@
 package main
 import (
-    "gopkg.in/libgit2/git2go.v22"
+    "gopkg.in/libgit2/git2go.v23"
     "fmt"
     "strings"
     "os/exec"

--- a/local-gitconfig.go
+++ b/local-gitconfig.go
@@ -1,6 +1,6 @@
 package main
 import (
-    "gopkg.in/libgit2/git2go.v22"
+    "gopkg.in/libgit2/git2go.v23"
     "os/exec"
     "strings"
     "fmt"


### PR DESCRIPTION
git2 removed some constants, so git2go-v22 doesn't build against git2-23.
Archlinux doesn't usually keep old versions of libraries around, so this bump would save me from additionally maintaining git2-22.
