### PR TITLE
Adding Fedora specific steps because of package differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,31 @@ Install go-lang (if not already installed)
 $ brew install go
 ~~~
 
-When go-lang is installed:
+If go-lang is installed, install libgit2
 
 ~~~sh
 $ brew install libgit2
+~~~
+
+### Fedora
+
+Install go-lang (if not already installed)
+
+~~~sh
+$ yum install go
+~~~
+
+If go-lang is installed, install libgit2-devel
+
+~~~sh
+$ yum install libgit2-devel
+~~~
+
+### Final steps
+
+Install the required go packages
+
+~~~sh
 $ go get gopkg.in/libgit2/git2go.v23
 $ go get github.com/plouc/go-gitlab-client
 $ go get github.com/codegangsta/cli


### PR DESCRIPTION
The libgit2-devel package is needed on Red Hat flavors of linux instead of libgit2. Without this, you get an error when you try and install the go package for libgit2:

```
$ go get gopkg.in/libgit2/git2go.v23
# pkg-config --cflags libgit2
Package libgit2 was not found in the pkg-config search path.
Perhaps you should add the directory containing `libgit2.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libgit2' found
pkg-config: exit status 1
```

I duplicated a the install steps from the mac install for clarity of those that want to follow the directions exactly :)